### PR TITLE
fix(config): add correct defaults in `content` and remove `purge`

### DIFF
--- a/config.js
+++ b/config.js
@@ -160,10 +160,10 @@ const maxHeight = (theme) => ({
 
 const windmillConfig = {
   darkMode: 'class',
-  purge: {
-    content: [
-      'node_modules/@windmill/react-ui/lib/defaultTheme.js',
-      'node_modules/@windmill/react-ui/dist/index.js',
+  content: {
+    files: [
+      'node_modules/windmill-react-ui-kit/lib/defaultTheme.js',
+      'node_modules/windmill-react-ui-kit/dist/index.js',
     ],
   },
   theme: {
@@ -198,15 +198,15 @@ function arrayMergeFn(destinationArray, sourceArray) {
  * @return {object} new config object
  */
 function wrapper(tailwindConfig) {
-  let purge
-  if (Array.isArray(tailwindConfig.purge)) {
-    purge = {
-      content: tailwindConfig.purge,
+  let content
+  if (Array.isArray(tailwindConfig.content)) {
+    content = {
+      files: tailwindConfig.content,
     }
   } else {
-    purge = tailwindConfig.purge
+    content = tailwindConfig.content
   }
-  return deepMerge({ ...tailwindConfig, purge }, windmillConfig, { arrayMerge: arrayMergeFn })
+  return deepMerge({ ...tailwindConfig, content }, windmillConfig, { arrayMerge: arrayMergeFn })
 }
 
 module.exports = wrapper

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@windmill/react-ui",
-  "version": "0.6.0",
+  "name": "windmill-react-ui-kit",
+  "version": "0.7.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@windmill/react-ui",
-      "version": "0.6.0",
+      "name": "windmill-react-ui-kit",
+      "version": "0.7.4",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/aspect-ratio": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "windmill-react-ui-kit",
-  "version": "0.7.4",
+  "version": "0.8.4",
   "description": "A fork of @windmill/react-ui with many upgrades.",
   "main": "dist/index.js",
   "files": [
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "tailwindcss": ">=2.0.0"
+    "tailwindcss": ">=3.0.0"
   },
   "dependencies": {
     "@tailwindcss/aspect-ratio": "^0.4.0",

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,0 +1,51 @@
+const windmillConfig = require('../../config')
+
+describe('windmill configuration', () => {
+  it('should include right defaults for `content` field', () => {
+    expect(
+      windmillConfig({
+        content: ['./app/**/*.{ts,tsx,jsx,js}'],
+      }).content
+    ).toEqual({
+      files: [
+        './app/**/*.{ts,tsx,jsx,js}',
+        'node_modules/windmill-react-ui-kit/lib/defaultTheme.js',
+        'node_modules/windmill-react-ui-kit/dist/index.js',
+      ],
+    })
+  })
+
+  it('should include right defaults for `content` when passing as object', () => {
+    expect(
+      windmillConfig({
+        content: {
+          files: ['./app/**/*.{ts,tsx,jsx,js}'],
+        },
+      }).content
+    ).toEqual({
+      files: [
+        './app/**/*.{ts,tsx,jsx,js}',
+        'node_modules/windmill-react-ui-kit/lib/defaultTheme.js',
+        'node_modules/windmill-react-ui-kit/dist/index.js',
+      ],
+    })
+  })
+
+  it('should include right defaults for `content` with additional fields', () => {
+    expect(
+      windmillConfig({
+        content: {
+          relative: true,
+          files: ['./app/**/*.{ts,tsx,jsx,js}'],
+        },
+      }).content
+    ).toEqual({
+      relative: true,
+      files: [
+        './app/**/*.{ts,tsx,jsx,js}',
+        'node_modules/windmill-react-ui-kit/lib/defaultTheme.js',
+        'node_modules/windmill-react-ui-kit/dist/index.js',
+      ],
+    })
+  })
+})

--- a/style/tailwind.config.js
+++ b/style/tailwind.config.js
@@ -1,10 +1,10 @@
 const windmill = require('../config')
 
 module.exports = windmill({
-  purge: ["./src/**/*.{html,js,ts,tsx}"],
+  purge: ['./src/**/*.{html,js,ts,tsx}'],
   // purge: [],
   theme: {
-    extend: {}
+    extend: {},
   },
   variants: {},
   plugins: [
@@ -13,6 +13,6 @@ module.exports = windmill({
       strategy: 'class',
     }),
     require('@tailwindcss/line-clamp'),
-    require('@tailwindcss/aspect-ratio')
+    require('@tailwindcss/aspect-ratio'),
   ],
 })


### PR DESCRIPTION
In issue #1 it was mentioned that `content` does not use the correct theme files. So I updated to use the the correct files and added tests for. Also, remove the `purge` and added `content` as per the [Upgrade guide](https://tailwindcss.com/docs/upgrade-guide#upgrade-packages).

BREAKING CHANGES: this commit changes `purge` to content according to TailwindCSS v2->v3 upgrade guide(https://tailwindcss.com/docs/upgrade-guide#upgrade-packages).