### PR TITLE
Bugfix/dropdown r17 fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run lint && npm run test:coverage"
+      "pre-commit": "npm run lint && npm run test"
     }
   }
 }

--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -27,21 +27,23 @@ const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>(function Dropdo
 
   const baseStyle = dropdown.base
   const alignStyle = dropdown.align[align]
-
-  function handleEsc(e: KeyboardEvent) {
-    if (e.key === 'Esc' || e.key === 'Escape') {
-      onClose()
-    }
-  }
-
   const dropdownRef = useRef<HTMLUListElement>(null)
-  function handleClickOutside(e: MouseEvent) {
-    if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
-      onClose()
-    }
-  }
+
+  const closeRef = useRef(onClose);
+  closeRef.current = onClose;
 
   useEffect(() => {
+    function handleEsc(e: KeyboardEvent) {
+        if (e.key === 'Esc' || e.key === 'Escape') {
+          closeRef.current()
+        }
+      }
+      function handleClickOutside(e: MouseEvent) {
+        if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+          closeRef.current()
+        }
+      }
+
     document.addEventListener('click', handleClickOutside, { capture: true })
     document.addEventListener('keydown', handleEsc, { capture: true })
     return () => {

--- a/style/tailwind.config.js
+++ b/style/tailwind.config.js
@@ -1,10 +1,10 @@
 const windmill = require('../config')
 
 module.exports = windmill({
-  purge: ["./src/**/*.{html,js,ts,tsx}"],
+  purge: ['./src/**/*.{html,js,ts,tsx}'],
   // purge: [],
   theme: {
-    extend: {}
+    extend: {},
   },
   variants: {},
   plugins: [
@@ -13,6 +13,6 @@ module.exports = windmill({
       strategy: 'class',
     }),
     require('@tailwindcss/line-clamp'),
-    require('@tailwindcss/aspect-ratio')
+    require('@tailwindcss/aspect-ratio'),
   ],
 })


### PR DESCRIPTION
Solved issues:

- Pre-commit ES Lint issues
- Precommit Jest issues: Note: Will remove `test:coverage` and only do regular `test`.
- Dropdown possibility of not working with React 17 or any given ESLint dependencies hook issues, etc. (eg. missing array dependencies for function calls within UseEffect hook method)
- Dropdown findDomNode warnings in Strict Mode for the component when opening/closing it.